### PR TITLE
Rebuild for lal-6.21.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -46,7 +46,6 @@ jobs:
       export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-      conda install --yes --quiet -c conda-forge "conda<4.7.11a0"  # HACK
     env: {
       OSX_FORCE_SDK_DOWNLOAD: "1"
     }

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,7 +20,6 @@ conda-build:
 CONDARC
 
 conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
-conda install --yes --quiet -c conda-forge "conda<4.7.11a0"  # HACK
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/0001-Comment-out-Inject.h-from-BayesWave.h-imports.-Any-f.patch
+++ b/recipe/0001-Comment-out-Inject.h-from-BayesWave.h-imports.-Any-f.patch
@@ -1,0 +1,27 @@
+From 71a856e27ed65faf81b97e8b1dce79400ae00710 Mon Sep 17 00:00:00 2001
+From: James Clark <james.clark@ligo.org>
+Date: Fri, 13 Dec 2019 11:43:14 -0800
+Subject: [PATCH] Comment-out Inject.h from BayesWave.h imports.  Any
+ functionality required from this should already be included in
+ LALInferenceReadData()
+
+---
+ src/BayesWave.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/BayesWave.h b/src/BayesWave.h
+index 59392a5..cc92e45 100644
+--- a/src/BayesWave.h
++++ b/src/BayesWave.h
+@@ -50,7 +50,7 @@
+ #include <lal/GenerateInspiral.h>
+ #include <lal/GeneratePPNInspiral.h>
+ #include <lal/SimulateCoherentGW.h>
+-#include <lal/Inject.h>
++//#include <lal/Inject.h>
+ #include <lal/LIGOMetadataTables.h>
+ #include <lal/LIGOMetadataUtils.h>
+ #include <lal/LIGOMetadataInspiralUtils.h>
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,13 @@ package:
 source:
   url: "http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.xz"
   sha256: 1dcf9ccf5457524c909d21467e2614f6ac2f581ca20bd209a5b3408e3f7e9536
+  patches:
+    - 0001-Comment-out-Inject.h-from-BayesWave.h-imports.-Any-f.patch
 
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
This rebuild should bump the lal dependency up to 6.21.0. This requires a patch, see https://git.ligo.org/lscsoft/bayeswave/commit/71a856e27ed65faf81b97e8b1dce79400ae00710.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
